### PR TITLE
Feat/use js instead of ts react

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+## Link to issue
+
+Please add a link to any relevant issues/tickets
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] New feature (non-breaking change that adds functionality)
+- [ ] Refactor (non-breaking change that updates existing functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Comments have been added/updated

--- a/create-webnative-app.ts
+++ b/create-webnative-app.ts
@@ -17,6 +17,7 @@ import isFolderEmpty from './helpers/is-folder-empty'
 import getOnline from './helpers/is-online'
 import isWriteable from './helpers/is-writeable'
 import { writeAppInfo, type AppInfo } from './helpers/set-app-info'
+import { switchToJavaScript } from './helpers/set-typescript'
 import type { AuthFlow } from './helpers/set-auth-flow'
 import type { Framework } from './helpers/set-framework'
 import type { PackageManager } from './helpers/get-pkg-manager'
@@ -24,12 +25,12 @@ import type { PackageManager } from './helpers/get-pkg-manager'
 export class DownloadError extends Error {}
 
 type Options = {
-  appInfo?: AppInfo;
-  appPath: string;
-  authFlow: AuthFlow;
-  framework: Framework;
-  packageManager: PackageManager;
-  typescript?: boolean;
+  appInfo?: AppInfo
+  appPath: string
+  authFlow: AuthFlow
+  framework: Framework
+  packageManager: PackageManager
+  removeTypescript?: boolean
 }
 
 type ReposType = {
@@ -61,6 +62,7 @@ const createWebnativeApp = async ({
   authFlow,
   framework,
   packageManager,
+  removeTypescript,
 }: Options): Promise<void> => {
   let repoInfo: RepoInfo | undefined
   let repoUrl: URL | undefined
@@ -173,6 +175,11 @@ const createWebnativeApp = async ({
     // Write app-info.ts values
     if (appInfo) {
       await writeAppInfo({ appInfo, authFlow, framework, root })
+    }
+
+    // Conver TS project to JS
+    if (removeTypescript) {
+      await switchToJavaScript({ framework, root })
     }
 
     hasPackageJson = fs.existsSync(packageJsonPath)

--- a/helpers/set-app-info.ts
+++ b/helpers/set-app-info.ts
@@ -106,7 +106,7 @@ export const writeAppInfo = async ({
 }: WriteAppInfoParams): Promise<void> => {
   try {
     const appInfoPath = `${root}/src/lib/app-info.ts`
-    const originalFile = fs.readFileSync(appInfoPath, 'utf8')
+    const originalFile = await fs.promises.readFile(appInfoPath, 'utf8')
     let defaultAppInfo =
       authFlow === AuthFlow.WalletAuth ? { ...APP_INFO_WALLET_AUTH } : { ...APP_INFO_WAT }
 
@@ -148,7 +148,7 @@ export const writeAppInfo = async ({
     //   `appImageURL = '${appInfo.appImageURL}'`,
     // )
 
-    fs.writeFileSync(appInfoPath, edits, 'utf8')
+    await fs.promises.writeFile(appInfoPath, edits, 'utf8')
 
     console.log()
     console.log(`Writing to app-info.ts at ${chalk.hex(PINK)(appInfoPath)}.`)

--- a/helpers/set-typescript.ts
+++ b/helpers/set-typescript.ts
@@ -133,28 +133,22 @@ const switchReactToJavascript = async (root: string): Promise<void> => {
 }
 
 /**
+ * TODO: Create SvelteKit TS -> JS transpiler
  * Switch a SvelteKit codebase to JavaScript
  *
  * @param root
  */
 const switchSvelteKitToJavascript = async (root: string): Promise<void> => {
   try {
-    const srcPath = `${root}/src`
-
     const packagesToRemove: {
       dependencies: string[]
-      devDependencies: string[]
     } = {
       dependencies: [
-        '@types/jest',
-        '@types/node',
-        '@types/react',
-        '@types/react-dom',
-      ],
-      devDependencies: [
-        '@types/qrcode-svg',
         '@typescript-eslint/eslint-plugin',
         '@typescript-eslint/parser',
+        'ts-node',
+        'tsconfig-paths',
+        'tslib',
         'typescript',
       ],
     }
@@ -165,9 +159,6 @@ const switchSvelteKitToJavascript = async (root: string): Promise<void> => {
     )
     packagesToRemove.dependencies.forEach(
       (pkg) => delete packageJsonFile.dependencies[pkg],
-    )
-    packagesToRemove.devDependencies.forEach(
-      (pkg) => delete packageJsonFile.devDependencies[pkg],
     )
 
     // Navigate to the root of the codebase
@@ -190,41 +181,6 @@ const switchSvelteKitToJavascript = async (root: string): Promise<void> => {
     execSync('rm tsconfig.json', {
       stdio: 'inherit',
     })
-
-    // Remove any .ts and .tsx files from the src directiory
-    execSync(
-      `cd ${srcPath} & find . -type f -name '*.ts' -exec rm {} + & find . -type f -name '*.tsx' -exec rm {} +`,
-      {
-        stdio: 'inherit',
-      },
-    )
-
-    // Remove TS-related code from eslint
-    const eslintrcFile = await fs.promises.readFile(
-      `${root}/.eslintrc.js`,
-      'utf8',
-    )
-
-    // Replace extends
-    let eslintrcEdits = eslintrcFile.replace(
-      '"plugin:@typescript-eslint/recommended",',
-      '',
-    )
-    eslintrcEdits = eslintrcEdits.replace(
-      'parser: "@typescript-eslint/parser",',
-      '',
-    )
-    eslintrcEdits = eslintrcEdits.replace(
-      'plugins: ["react", "@typescript-eslint"]',
-      'plugins: ["react"]',
-    )
-    eslintrcEdits = eslintrcEdits.replace(
-      '"@typescript-eslint/no-explicit-any": "off",',
-      '',
-    )
-
-    // Write the updated eslintrc file
-    await fs.promises.writeFile(`${root}/.eslintrc.js`, eslintrcEdits, 'utf8')
 
     // Write the updated package.json file
     await fs.promises.writeFile(

--- a/helpers/set-typescript.ts
+++ b/helpers/set-typescript.ts
@@ -1,0 +1,276 @@
+import chalk from 'chalk'
+import { execSync } from 'child_process'
+import fs from 'fs'
+import prompts from 'prompts'
+
+import { PINK } from './colours'
+import { AuthFlow } from './set-auth-flow'
+import { Framework } from './set-framework'
+
+/**
+ * Prompt the user to choose to use TypeScript or not(default is to use TS)
+ */
+const setTypescript = async (): Promise<boolean> => {
+  try {
+    const confirmRes = await prompts({
+      type: 'confirm',
+      name: 'useTypescript',
+      message: `Would you like to remove TypeScript from your project?`,
+      initial: false,
+    })
+
+    return confirmRes.useTypescript
+  } catch (error) {
+    console.error(error)
+  }
+
+  return false
+}
+
+/**
+ * Switch a React codebase to JavaScript
+ *
+ * @param root
+ */
+const switchReactToJavascript = async (root: string): Promise<void> => {
+  try {
+    const srcPath = `${root}/src`
+
+    const packagesToRemove: {
+      dependencies: string[]
+      devDependencies: string[]
+    } = {
+      dependencies: [
+        '@types/jest',
+        '@types/node',
+        '@types/react',
+        '@types/react-dom',
+      ],
+      devDependencies: [
+        '@types/qrcode-svg',
+        '@typescript-eslint/eslint-plugin',
+        '@typescript-eslint/parser',
+        'typescript',
+      ],
+    }
+
+    // Remove TS-related packages
+    const packageJsonFile = JSON.parse(
+      await fs.promises.readFile(`${root}/package.json`, 'utf8'),
+    )
+    packagesToRemove.dependencies.forEach(
+      (pkg) => delete packageJsonFile.dependencies[pkg],
+    )
+    packagesToRemove.devDependencies.forEach(
+      (pkg) => delete packageJsonFile.devDependencies[pkg],
+    )
+
+    // Navigate to the root of the codebase
+    execSync(`cd ${root}`, {
+      stdio: 'inherit',
+    })
+
+    /**
+     * This command catches after converting TS files to JS because type
+     * imports are no longer available, but we don't want that to interrupt
+     * the flow of the parent function
+     */
+    try {
+      execSync('npx tsc --jsx preserve -t es2020 --noEmit false', {
+        stdio: 'ignore',
+      })
+    } catch (error) {}
+
+    // Remove the tsconfig
+    execSync('rm tsconfig.json', {
+      stdio: 'inherit',
+    })
+
+    // Remove any .ts and .tsx files from the src directiory
+    execSync(
+      `cd ${srcPath} & find . -type f -name '*.ts' -exec rm {} + & find . -type f -name '*.tsx' -exec rm {} +`,
+      {
+        stdio: 'inherit',
+      },
+    )
+
+    // Remove TS-related code from eslint
+    const eslintrcFile = await fs.promises.readFile(
+      `${root}/.eslintrc.js`,
+      'utf8',
+    )
+
+    // Replace extends
+    let eslintrcEdits = eslintrcFile.replace(
+      '"plugin:@typescript-eslint/recommended",',
+      '',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      'parser: "@typescript-eslint/parser",',
+      '',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      'plugins: ["react", "@typescript-eslint"]',
+      'plugins: ["react"]',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      '"@typescript-eslint/no-explicit-any": "off",',
+      '',
+    )
+
+    // Write the updated eslintrc file
+    await fs.promises.writeFile(`${root}/.eslintrc.js`, eslintrcEdits, 'utf8')
+
+    // Write the updated package.json file
+    await fs.promises.writeFile(
+      `${root}/package.json`,
+      JSON.stringify(packageJsonFile, null, 2),
+      'utf8',
+    )
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+/**
+ * Switch a SvelteKit codebase to JavaScript
+ *
+ * @param root
+ */
+const switchSvelteKitToJavascript = async (root: string): Promise<void> => {
+  try {
+    const srcPath = `${root}/src`
+
+    const packagesToRemove: {
+      dependencies: string[]
+      devDependencies: string[]
+    } = {
+      dependencies: [
+        '@types/jest',
+        '@types/node',
+        '@types/react',
+        '@types/react-dom',
+      ],
+      devDependencies: [
+        '@types/qrcode-svg',
+        '@typescript-eslint/eslint-plugin',
+        '@typescript-eslint/parser',
+        'typescript',
+      ],
+    }
+
+    // Remove TS-related packages
+    const packageJsonFile = JSON.parse(
+      await fs.promises.readFile(`${root}/package.json`, 'utf8'),
+    )
+    packagesToRemove.dependencies.forEach(
+      (pkg) => delete packageJsonFile.dependencies[pkg],
+    )
+    packagesToRemove.devDependencies.forEach(
+      (pkg) => delete packageJsonFile.devDependencies[pkg],
+    )
+
+    // Navigate to the root of the codebase
+    execSync(`cd ${root}`, {
+      stdio: 'inherit',
+    })
+
+    /**
+     * This command catches after converting TS files to JS because type
+     * imports are no longer available, but we don't want that to interrupt
+     * the flow of the parent function
+     */
+    try {
+      execSync('npx tsc --jsx preserve -t es2020 --noEmit false', {
+        stdio: 'ignore',
+      })
+    } catch (error) {}
+
+    // Remove the tsconfig
+    execSync('rm tsconfig.json', {
+      stdio: 'inherit',
+    })
+
+    // Remove any .ts and .tsx files from the src directiory
+    execSync(
+      `cd ${srcPath} & find . -type f -name '*.ts' -exec rm {} + & find . -type f -name '*.tsx' -exec rm {} +`,
+      {
+        stdio: 'inherit',
+      },
+    )
+
+    // Remove TS-related code from eslint
+    const eslintrcFile = await fs.promises.readFile(
+      `${root}/.eslintrc.js`,
+      'utf8',
+    )
+
+    // Replace extends
+    let eslintrcEdits = eslintrcFile.replace(
+      '"plugin:@typescript-eslint/recommended",',
+      '',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      'parser: "@typescript-eslint/parser",',
+      '',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      'plugins: ["react", "@typescript-eslint"]',
+      'plugins: ["react"]',
+    )
+    eslintrcEdits = eslintrcEdits.replace(
+      '"@typescript-eslint/no-explicit-any": "off",',
+      '',
+    )
+
+    // Write the updated eslintrc file
+    await fs.promises.writeFile(`${root}/.eslintrc.js`, eslintrcEdits, 'utf8')
+
+    // Write the updated package.json file
+    await fs.promises.writeFile(
+      `${root}/package.json`,
+      JSON.stringify(packageJsonFile, null, 2),
+      'utf8',
+    )
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+type FunctionMap = {
+  [Framework.React]: (root: string) => Promise<void>,
+  [Framework.SvelteKit]: (root: string) => Promise<void>,
+}
+const functionMap: FunctionMap = {
+  [Framework.React]: (root: string) => switchReactToJavascript(root),
+  [Framework.SvelteKit]: (root: string) => switchSvelteKitToJavascript(root),
+}
+
+type SwitchToJavaScriptParams = {
+  framework: Framework
+  root: string
+}
+
+/**
+ * Convert a TS project to JS if the user as set `useTypescript` to `false`
+ *
+ * @param SwitchToJavaScriptParams
+ */
+export const switchToJavaScript = async ({
+  framework,
+  root,
+}: SwitchToJavaScriptParams): Promise<void> => {
+  try {
+    await functionMap[framework](root)
+
+    console.log()
+    console.log(
+      `Removing TypeScript from your project at ${chalk.hex(PINK)(root)}.`,
+    )
+    console.log()
+  } catch (err) {
+    console.error(err)
+  }
+}
+
+export default setTypescript

--- a/index.ts
+++ b/index.ts
@@ -98,8 +98,8 @@ const run = async (): Promise<void> => {
   // Detect the selected framework or ask the user which they'd prefer
   const framework = await setFramework(program)
 
-  // Ask the user if they'd like to remove TypeScript
-  const removeTypescript = await setTypescript()
+  // Ask the user if they'd like to remove TypeScript(currently only supported in the React build)
+  const removeTypescript = framework === Framework.React ? await setTypescript() : false
 
   // Ask the user if they would like to change the default app-info.ts values(og:title, og:description, etc...)
   const appInfo = await setAppInfo(authFlow)

--- a/index.ts
+++ b/index.ts
@@ -12,6 +12,7 @@ import setAppInfo, { AppInfo } from './helpers/set-app-info'
 import setAuthFlow, { AuthFlow } from './helpers/set-auth-flow'
 import setFramework, { Framework } from './helpers/set-framework'
 import setProjectPath from './helpers/set-project-path'
+import setTypescript from './helpers/set-typescript'
 import packageJson from './package.json'
 
 export type CWA_Command = CommandType & {
@@ -84,13 +85,6 @@ const program: CWA_Command = new Command(packageJson.name)
   Explicitly tell the CLI to build the application using Webnative's Device Linking flow
 `,
   )
-  // TODO: Add option of generating apps without typescript
-  //   .option(
-  //     '--ts, --typescript',
-  //     `
-  //   Initialize as a TypeScript project.
-  // `
-  //   )
   .allowUnknownOption()
   .parse(process.argv)
 
@@ -103,6 +97,9 @@ const run = async (): Promise<void> => {
 
   // Detect the selected framework or ask the user which they'd prefer
   const framework = await setFramework(program)
+
+  // Ask the user if they'd like to remove TypeScript
+  const removeTypescript = await setTypescript()
 
   // Ask the user if they would like to change the default app-info.ts values(og:title, og:description, etc...)
   const appInfo = await setAppInfo(authFlow)
@@ -118,7 +115,7 @@ const run = async (): Promise<void> => {
       )} because of npm naming restrictions:`
     )
 
-    problems!.forEach((p) => console.error(`    ${chalk.red.bold('*')} ${p}`))
+    problems!.forEach((p) => console.error(` ${chalk.red.bold('*')} ${p}`))
     process.exit(1)
   }
 
@@ -135,8 +132,7 @@ const run = async (): Promise<void> => {
       authFlow,
       framework,
       packageManager,
-      // TODO: Add option of generating apps without typescript
-      // typescript: program.typescript,
+      removeTypescript,
     })
   } catch (reason) {
     if (!(reason instanceof DownloadError)) {
@@ -149,8 +145,7 @@ const run = async (): Promise<void> => {
       authFlow: AuthFlow.DeviceLinking,
       framework: Framework.SvelteKit,
       packageManager,
-      // TODO: Add option of generating apps without typescript
-      // typescript: program.typescript,
+      removeTypescript,
     })
   }
 }


### PR DESCRIPTION
# Description

Adding the ability to use JS instead of TS when building one of the React repos. It will take some extra work to add that functionality to the SvelteKit repos because `tsc` can't transpile ts files to js in a svelte project. I'll need to build a transpiler in a follow up PR 👍🏼 I'm doing this via a prompt when the user chooses React as their framework. I'll create a flag for this too once the SvelteKit version is working.

I've also updated the uses of `fs` throughout the codebase to use `fs.promises` instead

## Link to issue

https://github.com/webnative-examples/create-webnative-app/issues/2

## Type of change

- [x] New feature (non-breaking change that adds functionality)
- [x] Refactor (non-breaking change that updates existing functionality)
